### PR TITLE
feat: add local llm url env, default to standard Ollama URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,5 @@
 # `cai` - The fastest CLI tool for prompting LLMs
 
-
 ## Features
 
 - Build with Rust 🦀 for supreme performance and speed! 🏎️
@@ -13,18 +12,15 @@
 [OpenAI]: https://platform.openai.com/docs/models
 [Anthropic]: https://docs.anthropic.com/claude/docs/models-overview
 
-
 ## Demo
 
 ![`cai` demo](./demos/main.gif)
-
 
 ## Installation
 
 ```sh
 cargo install cai
 ```
-
 
 ## Usage
 
@@ -37,9 +33,10 @@ Cai supports the following APIs:
 - **OpenAI** - [Create new API key](https://platform.openai.com/api-keys).
 - **Anthropic** -
     [Create new API key](https://console.anthropic.com/settings/keys).
-- **localhost:8080** - Any OpenAI API compatible local server (E.g. [llamafile])
+- **Locally Hosted (OpenAI Compatible)** - Any OpenAI API compatible local server (E.g. [Ollama], [llamafile]), configured by setting `LOCAL_LLM_URL`, defaults to `http://127.0.0.1:14434/v1/chat/completions`
 
-[llamafile]: https://github.com/Mozilla-Ocho/llamafile
+- [Ollama]: https://github.com/ollama/ollama
+- [llamafile]: https://github.com/Mozilla-Ocho/llamafile
 
 Afterwards, you can use `cai` to run prompts directly from the terminal:
 
@@ -58,7 +55,6 @@ For more information, run:
 ```sh
 cai help
 ```
-
 
 ## Related
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub const CLAUDE_OPUS: &str = "claude-3-opus-20240307";
 pub const CLAUDE_SONNET: &str = "claude-3-sonnet-20240307";
 pub const CLAUDE_HAIKU: &str = "claude-3-haiku-20240307";
 pub const GROQ_MIXTRAL: &str = "mixtral-8x7b-32768";
+pub const LOCAL_LLM_URL: &str = "http://127.0.0.1:14434/v1/chat/completions";
 
 #[derive(Serialize, Debug, PartialEq, Default, Clone, Copy)]
 pub enum Provider {
@@ -126,7 +127,7 @@ fn default_req_for_provider(provider: &Provider) -> AiRequest {
     },
     Provider::Local => AiRequest {
       provider: Provider::Local,
-      url: "http://localhost:8080/v1/chat/completions".to_string(),
+      url: LOCAL_LLM_URL.to_string(),
       ..Default::default()
     },
   }


### PR DESCRIPTION
fixes #4 

- Add env for local LLM URL (defaults to Ollama / http://127.0.0.1:11434 - understand if you want to change this to whatever other URL your server uses)